### PR TITLE
Do not set theme name. RPMs now take care of it

### DIFF
--- a/nemo-armv7hl-n950-rnd.ks
+++ b/nemo-armv7hl-n950-rnd.ks
@@ -168,10 +168,6 @@ ti-omap3-sgx-wayland-wsegl
 
 Config_Src=`gconftool-2 --get-default-source`
 
-#Set theme name
-gconftool-2 --direct --config-source $Config_Src \
-  -s -t string /meegotouch/theme/name "darko"
-
 # Set up proper target for libmeegotouch
 gconftool-2 --direct --config-source $Config_Src \
   -s -t string /meegotouch/target/name N950

--- a/nemo-i486-vm-wayland.ks
+++ b/nemo-i486-vm-wayland.ks
@@ -148,12 +148,6 @@ gst-plugins-good
 
 %post
 
-Config_Src=`gconftool-2 --get-default-source`
-
-#Set theme name
-gconftool-2 --direct --config-source $Config_Src \
-  -s -t string /meegotouch/theme/name "darko"
-
 ## rpm-rebuilddb.post from mer-kickstarter-configs package
 # Rebuild db using target's rpm
 echo -n "Rebuilding db using target rpm.."

--- a/nemo-i486-vm-wayland_SB2.ks
+++ b/nemo-i486-vm-wayland_SB2.ks
@@ -138,12 +138,6 @@ glibc-devel
 
 %post
 
-Config_Src=`gconftool-2 --get-default-source`
-
-#Set theme name
-gconftool-2 --direct --config-source $Config_Src \
-  -s -t string /meegotouch/theme/name "darko"
-
 ## rpm-rebuilddb.post from mer-kickstarter-configs package
 # Rebuild db using target's rpm
 echo -n "Rebuilding db using target rpm.."


### PR DESCRIPTION
meegotouch-theme-darko sets theme name to 'darko', when pulled in (via mic or zypper)
nemo-theme-default now sets theme name to 'base' , if no other theme is set (so nemo-theme-default updates do not break anything ;))
