### PR TITLE
launch all oneshot jobs on device's first boot

### DIFF
--- a/nemo-armv7hl-n950-rnd.ks
+++ b/nemo-armv7hl-n950-rnd.ks
@@ -26,7 +26,12 @@ repo --name=mer-qt --baseurl=http://repo.merproject.org/obs/mer:/qt:/devel/lates
 
 %end
 
+%pre
+touch $INSTALL_ROOT/.bootstrap
+%end
+
 %post
+rm $INSTALL_ROOT/.bootstrap
 
 Config_Src=`gconftool-2 --get-default-source`
 


### PR DESCRIPTION
(tested and working on n9 ;))

this fixes the need to `ssu ur` on device, as this is now elegantly
taken care by oneshot rule in ssu-vendor-data-nemo .spec, which will
fire on device, and not while mic is baking image
